### PR TITLE
accept message object/array + adjust message value

### DIFF
--- a/src/Producer.js
+++ b/src/Producer.js
@@ -22,9 +22,24 @@ class Producer {
       throw new Error("You need send a json object in data argument");
     }
 
+    let messages = Array.isArray(data) ? data : [data];
+    messages = messages.map(message => {
+      if (!message.value) {
+        message = { 
+          value: JSON.stringify(message) 
+        }
+      }
+      
+      if (typeof message.value !== "string") {
+        message.value = JSON.stringify(message.value);
+      }
+
+      return message;
+    });
+
     await this.producer.send({
       topic,
-      messages: data,
+      messages,
     });
 
     this.Logger.info("sent data to kafka.");


### PR DESCRIPTION
The example show for us that we can send a message like this: 
```
const data = {};
Kafka.send('topic', data);
```

But I tried to use, and I discovered that the right way to send a message is:
```
const data = [{ value: 'my value need to be a string' }];
Kafka.send('topic', data);
```

So to be clear and easy to use, I fixed message param and now we can send the message as we want:
```
const firstMessage = { mykey: 'myvalue' };
const secondMessage = { value: { mykey: 'my value' } }
const thirdMessage = { value: 'myvalue' }
const messages = [firstMessage, secondMessage, thirdMessage]

// the message param can be anyone of these 4 examples
```